### PR TITLE
Provided solution to CSModel cleanup

### DIFF
--- a/lua/weapons/weapon_wattlebase/shared.lua
+++ b/lua/weapons/weapon_wattlebase/shared.lua
@@ -406,9 +406,11 @@ function SWEP:OnRemove()
 	self:WatOnRemove()
 end
 
-function WattleEntityRemoved(ent)
+local function WattleEntityRemoved(ent)
 	if(CLIENT) then
-		if(ent.Wattle) then
+		if(ent.Wattle) and (CurTime() > (WATTLE_JOINED_TIME + 30)) then
+			--print("DEBUG:   " .. CurTime())
+			--print("DEBUG:   " .. WATTLE_JOINED_TIME + 30)
 			if(ent.VElements) then
 				ent:RemoveModels(ent.VElements)
 			end
@@ -419,6 +421,12 @@ function WattleEntityRemoved(ent)
 	end
 end
 hook.Add("EntityRemoved", "WattleEntityRemoved", WattleEntityRemoved)
+
+hook.Add("InitPostEntity", "WattleClavSetSetJoinTime", function(ply)
+	if CLIENT then
+		WATTLE_JOINED_TIME = CurTime()
+	end
+end)
 
 function SWEP:Think()
 	self:WatThink()


### PR DESCRIPTION
There was an issue where every single weapon on the map, including the players' weapons, would have their CSModels deleted even though the weapons themeselves weren't removed. By introducing a delay before the garbage collector can take effect, this should solve the problem for the time being. Results may vary by load time.
